### PR TITLE
Fix an issue that prevents the ABY framework container to be built

### DIFF
--- a/aby/README.md
+++ b/aby/README.md
@@ -5,7 +5,7 @@ ABY switches between three protocols: a GMW-based __A__rithmetic protocol that u
 
 ABY was developed by Daniel Demmler, Thomas Schneider and Michael Zohner in the [ENCRYPTO group](https://www.encrypto.informatik.tu-darmstadt.de/encrypto/) at TU Darmstadt.
 
-Our recommendation: ABY provides a powerful low-level crytographic interface that gives the developer significant control over performance. We recommend ABY for users who are familiara with MPC protocols, their relative tradeoffs, and the circuit model of computation.
+Our recommendation: ABY provides a powerful low-level crytographic interface that gives the developer significant control over performance. We recommend ABY for users who are familiar with MPC protocols, their relative tradeoffs, and the circuit model of computation.
 
 ## Docker setup
 

--- a/aby/install.sh
+++ b/aby/install.sh
@@ -2,7 +2,7 @@
 # get ABY
 git clone --recursive https://github.com/encryptogroup/ABY.git
 cd ABY
-git checkout -b MPCSOK f52fef85cb8d301440605fb101e1a9e4f7302b04
+git checkout -b MPCSOK 5535bf80541c09682d776fcebe7000213ecad25f
 
 # copy our working examples 
 for EX in mult3 crosstabs innerprod


### PR DESCRIPTION
The current version of the _frameworks_ repository did not succeed in building the ABY framework. I suggest to use a more recent commit of the ABY framework, which fixes the problem. 