### PR TITLE
update to v1.8.1

### DIFF
--- a/scalemamba/Dockerfile
+++ b/scalemamba/Dockerfile
@@ -1,5 +1,8 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
+
 WORKDIR /root
+
+# Install required packages
 RUN apt-get update && apt-get install -y \
   bzip2 \
   doxygen \
@@ -8,6 +11,7 @@ RUN apt-get update && apt-get install -y \
   git \
   libcrypto++-dev \
   libgmp3-dev \
+  libssl-dev \
   m4 \
   make \
   patch \
@@ -25,5 +29,7 @@ ADD install.sh .
 RUN ["bash", "install.sh"]
 
 ADD README.md .
+
+ENV PATH ~/.cargo/bin/:${PATH}
 
 CMD ["/bin/bash"]

--- a/scalemamba/install.sh
+++ b/scalemamba/install.sh
@@ -3,7 +3,7 @@
 cd 
 git clone https://github.com/KULeuven-COSIC/SCALE-MAMBA.git
 cd SCALE-MAMBA
-git checkout -b MPCSOK d7c960afd
+git checkout -b v1.8.1 e3488e646ed71e8d3264e2f3fe8e2226d4d503a9
 cp /root/source/CONFIG.mine .
 make progs
 

--- a/scalemamba/install_dependencies.sh
+++ b/scalemamba/install_dependencies.sh
@@ -4,17 +4,8 @@ tar -xvf mpir-3.0.0.tar.bz2
 rm mpir-3.0.0.tar.bz2
 cd mpir-3.0.0
 ./configure --enable-cxx
-make && make check && make install
-cp .libs/* /usr/lib64/
+make
+make check
+make install
 
-# install openssl from source because apparently apt's version is not good
-# enough
-cd
-wget https://www.openssl.org/source/openssl-1.1.0h.tar.gz
-tar -xvf openssl-1.1.0h.tar.gz
-rm openssl-1.1.0h.tar.gz
-cd openssl-1.1.0h
-./config
-make && make install
-ldconfig 
-
+curl -sSf sh.rustup.rs | sh -s -- -y

--- a/scalemamba/source/CONFIG.mine
+++ b/scalemamba/source/CONFIG.mine
@@ -1,15 +1,22 @@
 ROOT = /root/SCALE-MAMBA
-OSSL = /root/openssl-1.1.0h
+OSSL =
 
 # Debug flags
 #   SH_DEBUG = Share debugging (for development only)
 #   DEBUG = Checks for reads before writes on register access
 #   DETERMINISTIC = Removes all randomness, gain for debugging
 
-MAX_MOD = 10
+# MAX_MOD = 7 should be OK for 128 bit based FHE operations
+MAX_MOD = 7
 
-#FLAGS = -DSH_DEBUG -DDEBUG -DMAX_MOD_SZ=$(MAX_MOD) -DDETERMINISTIC
+# Benchmark flags
+#   BENCH_NETDATA = Enable benchmarking of network data
+#   BENCH_MEMORY  = Enable benchmarking of memory 
+
+#FLAGS = -DSH_DEBUG -DDEBUG -DMAX_MOD_SZ=$(MAX_MOD) -DDETERMINISTIC -DBENCH_NETDATA -DBENCH_MEMORY
 FLAGS = -DMAX_MOD_SZ=$(MAX_MOD) 
 
-OPT = -O3
+OPT = -O3 
+
+LDFLAGS = 
 


### PR DESCRIPTION
Here are my changes made to update the setup to the new scale mamba v1.8.1 version;

1. Most notably I switched to a newer ubuntu version allowing us to remove the custom openssl install!
2. Since the compiler is now using another optimization layer (compiler) in rust, I added a rust installation.
3. I also updated the CONFIG.MINE and 
4. changed the checkout to use a version naming since the SCALE-MAMBA itself does not tag anything, so it becomes much more clear what we actually checkout just from one look! 

Cheers