### PR TITLE
Some Makefile fixes for EMP

### DIFF
--- a/emp/ag_test/CMakeLists.txt
+++ b/emp/ag_test/CMakeLists.txt
@@ -3,7 +3,7 @@ project (emp-docker-test)
 set(NAME "emp-docker-test")
 
 find_path(CMAKE_FOLDER NAMES cmake/emp-tool-config.cmake)
-include(${CMAKE_FOLDER}/cmake/common.cmake)
+include(${CMAKE_FOLDER}/cmake/emp-base.cmake)
 include(${CMAKE_FOLDER}/cmake/enable_rdseed.cmake)
 include(${CMAKE_FOLDER}/cmake/enable_float.cmake)
 
@@ -13,9 +13,5 @@ include_directories(${EMP-SH2PC_INCLUDE_DIRS})
 find_package(emp-ag2pc REQUIRED)
 include_directories(${EMP-AG2PC_INCLUDE_DIRS})
 
-macro (add_test _name)
-	add_test_with_lib(${_name} ${EMP-TOOL_LIBRARIES})
-endmacro()
-
-add_test(agmult3)
-add_test(mult3.ag2pc)
+enable_testing()
+add_subdirectory(test)

--- a/emp/ag_test/test/CMakeLists.txt
+++ b/emp/ag_test/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+#Testing macro
+macro (add_test_executable_with_lib _name libs)
+	add_executable(${_name} "${_name}.cpp")
+	target_link_libraries(${_name} ${EMP-OT_LIBRARIES})
+endmacro()
+
+macro (add_test_case _name)
+	add_test_executable_with_lib(${_name} "")
+  	add_test(NAME ${_name} COMMAND "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${_name}" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/")
+endmacro()
+
+macro (add_test_case_with_run _name)
+	add_test_executable_with_lib(${_name} "")
+	add_test(NAME ${_name} COMMAND "./run" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${_name}" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/")
+endmacro()
+
+# Test cases
+add_test_case_with_run(agmult3)
+add_test_case_with_run(mult3.ag2pc)

--- a/emp/sh_test/CMakeLists.txt
+++ b/emp/sh_test/CMakeLists.txt
@@ -3,7 +3,7 @@ project (emp-docker-test)
 set(NAME "emp-docker-test")
 
 find_path(CMAKE_FOLDER NAMES cmake/emp-tool-config.cmake)
-include(${CMAKE_FOLDER}/cmake/common.cmake)
+include(${CMAKE_FOLDER}/cmake/emp-base.cmake)
 include(${CMAKE_FOLDER}/cmake/enable_rdseed.cmake)
 include(${CMAKE_FOLDER}/cmake/enable_float.cmake)
 


### PR DESCRIPTION
The EMP project recently made changes to their cmake file hierarchy. With the suggested changes the build process will work again. Also the ag_tests didn't build before. Now they do.