### PR TITLE
Update MP-SPDZ

### DIFF
--- a/mp-spdz/Dockerfile
+++ b/mp-spdz/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:16.04
+FROM python:3.9.16-bullseye
 WORKDIR /root
 RUN apt-get update && apt-get install -y \
   curl \
-  python3 \
   openssl \
   xz-utils
 
 ADD install.sh .
 RUN ["bash", "install.sh"]
 
-add README.md test_readme.sh ./
-add source/* ./MP-SPDZ/Programs/Source/
+ADD README.md test_readme.sh ./
+ADD source/* ./MP-SPDZ/Programs/Source/
+
+CMD ["/bin/bash"]

--- a/mp-spdz/README.md
+++ b/mp-spdz/README.md
@@ -17,10 +17,10 @@ $ docker run -it --rm mp-spdz
 
 ## Architecture
 
-While MP-SPDZ implements a number of schemes, we focus on computation
-modulo a 128-bit prime here. See the the MP-SPDZ
-[readme](https://github.com/data61/MP-SPDZ) for details on other
-domains such as computation modulo 2^k and binary circuits.
+While MP-SPDZ implements a number of schemes.
+We focus on computation using an integer length of 64.
+Computations are performed modulo a large enough prime here, which is output by the compiler.
+See the the MP-SPDZ [readme](https://github.com/data61/MP-SPDZ) for details on other domains such as computation modulo 2^k and binary circuits.
 
 ## Running examples
 
@@ -28,7 +28,7 @@ First, compile the example source. We provide three examples (mult3, innerprod,
 xtabs).
 ```
 $ cd MP-SPDZ
-$ ./compile.py -C -p 128 <ex>
+$ ./compile.py -C -F 64 <ex>
 ```
 The `-C` argument is optional but it speeds up the compilation of xtabs.
 

--- a/mp-spdz/install.sh
+++ b/mp-spdz/install.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-curl -L https://github.com/data61/MP-SPDZ/releases/download/v0.1.5/mp-spdz-0.1.5.tar.xz | tar xJv
-mv mp-spdz-0.1.5 MP-SPDZ
+MP_SPDZ_VERSION="0.3.6"
+
+curl -L https://github.com/data61/MP-SPDZ/releases/download/v$MP_SPDZ_VERSION/mp-spdz-$MP_SPDZ_VERSION.tar.xz | tar xJv
+mv mp-spdz-$MP_SPDZ_VERSION MP-SPDZ
 
 cd MP-SPDZ
 Scripts/tldr.sh

--- a/mp-spdz/test_readme.sh
+++ b/mp-spdz/test_readme.sh
@@ -3,12 +3,12 @@
 cd MP-SPDZ
 
 for i in mult3 innerprod xtabs; do
-    ./compile.py -C -p 128 $i || exit 1
+    ./compile.py $i || exit 1
 done
 
 Scripts/setup-ssl.sh 3
 
-mkdir Player-Data
+mkdir -p Player-Data
 echo 14 > Player-Data/Input-P0-0
 echo 12 > Player-Data/Input-P1-0
 echo 8 > Player-Data/Input-P2-0


### PR DESCRIPTION
Update MP-SPDZ from version 0.1.5 to the (currently latest) version 0.3.6.
For this, I also updated the README and test_readme.sh, as the `-p` option is no longer supported. Instead, the example command now uses the `-F` option.

We also now use a different docker base image.

I tested that test_readme.sh is still able to run without errors.