### PR TITLE
Update SCALEMAMBA's version and dependencies

### DIFF
--- a/scalemamba/Dockerfile
+++ b/scalemamba/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 WORKDIR /root
 
@@ -16,11 +16,17 @@ RUN apt-get update && apt-get install -y \
   m4 \
   make \
   patch \
-  python \
+  python3 \
+  python2 \
+  python-is-python3 \
   vim \
   wget \
   yasm \
-  zip
+  zip \
+  autotools-dev \
+  autoconf \
+  libtool \
+  texinfo
 
 ADD install_dependencies.sh .
 RUN ["bash", "install_dependencies.sh"]

--- a/scalemamba/README.md
+++ b/scalemamba/README.md
@@ -6,6 +6,9 @@ SCALE-MAMBA is developed by a team at KU Leuven and is available [on Github](htt
 
 Our recommendation: SCALE-MAMBA is an actively maintained, highly flexible, [extensively documented](https://homes.esat.kuleuven.be/~nsmart/SCALE/Documentation.pdf) framework. It supports an arbitrary number of parties and has strong security guarantees and we recommend it for most use cases. Our only caveat is that it may consume significant computing resources.
 
+Note on the project's maintenance status: in June '22, the authors have announced that the project is no longer actively maintained.
+Visit the project website for details.
+
 ## Docker Setup
 Create a Docker image. This will take a few minutes. You only have to do this
 once.

--- a/scalemamba/install.sh
+++ b/scalemamba/install.sh
@@ -1,9 +1,11 @@
+set -ex
 
-# download SCALE-MAMBA v1.5
+
+# download SCALE-MAMBA v1.14
 cd 
 git clone https://github.com/KULeuven-COSIC/SCALE-MAMBA.git
 cd SCALE-MAMBA
-git checkout -b v1.8.1 e3488e646ed71e8d3264e2f3fe8e2226d4d503a9
+git checkout -b v1.14 c111516e3ebc1efd12a2bd47dd2122b160e13d1e
 cp /root/source/CONFIG.mine .
 make progs
 

--- a/scalemamba/install_dependencies.sh
+++ b/scalemamba/install_dependencies.sh
@@ -1,8 +1,11 @@
+set -ex
+
 # install supporting mpir library
-wget http://mpir.org/mpir-3.0.0.tar.bz2
-tar -xvf mpir-3.0.0.tar.bz2
-rm mpir-3.0.0.tar.bz2
-cd mpir-3.0.0
+wget https://github.com/wbhart/mpir/archive/refs/tags/mpir-3.0.0.tar.gz
+tar -xvzf mpir-3.0.0.tar.gz
+rm mpir-3.0.0.tar.gz
+cd mpir-mpir-3.0.0
+./autogen.sh
 ./configure --enable-cxx
 make
 make check

--- a/scalemamba/source/CONFIG.mine
+++ b/scalemamba/source/CONFIG.mine
@@ -1,5 +1,5 @@
 ROOT = /root/SCALE-MAMBA
-OSSL =
+OSSL = 
 
 # Debug flags
 #   SH_DEBUG = Share debugging (for development only)
@@ -8,13 +8,14 @@ OSSL =
 
 # MAX_MOD = 7 should be OK for 128 bit based FHE operations
 MAX_MOD = 7
+MAX_GFP = 3
 
 # Benchmark flags
 #   BENCH_NETDATA = Enable benchmarking of network data
 #   BENCH_MEMORY  = Enable benchmarking of memory 
 
 #FLAGS = -DSH_DEBUG -DDEBUG -DMAX_MOD_SZ=$(MAX_MOD) -DDETERMINISTIC -DBENCH_NETDATA -DBENCH_MEMORY
-FLAGS = -DMAX_MOD_SZ=$(MAX_MOD) 
+FLAGS = -DMAX_MOD_SZ=$(MAX_MOD) -DMAX_GFP_SZ=$(MAX_GFP) 
 
 OPT = -O3 
 


### PR DESCRIPTION
Update to the latest version of SCALE-MAMBA, its dependencies and Ubuntu 22.04. Further, add a note in the README that the authors state that the project is no longer actively maintained.