### PR TITLE
Add a runscript for CBMC-GC and improve Dockerfile

### DIFF
--- a/cbmc-gc/Dockerfile
+++ b/cbmc-gc/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:16.04
+# Can't upgrade to ubuntu:22:04 since this causes bison 3.8.2 to be installed, which is incompatible
 WORKDIR /root
 RUN apt-get update && apt-get install -y \
   bison \
@@ -8,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   libwww-perl \
   make \
   patch \
-  python \
+  python3 \
   wget \
   vim
 

--- a/cbmc-gc/Dockerfile
+++ b/cbmc-gc/Dockerfile
@@ -11,10 +11,18 @@ RUN apt-get update && apt-get install -y \
   python \
   wget \
   vim
-ADD source/ /root/source
-ADD README.md .
+
 ADD install.sh .
 RUN ["bash", "install.sh"]
+
+WORKDIR /root/CBMC-GC-2
+
+ADD source/ ./examples/
+
+ADD README.md .
+
+ADD runall.sh .
+
 CMD ["/bin/bash"]
 
 

--- a/cbmc-gc/Dockerfile
+++ b/cbmc-gc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 # Can't upgrade to ubuntu:22:04 since this causes bison 3.8.2 to be installed, which is incompatible
 WORKDIR /root
 RUN apt-get update && apt-get install -y \

--- a/cbmc-gc/README.md
+++ b/cbmc-gc/README.md
@@ -73,7 +73,7 @@ your code:
 ```
 $ make
 ...
-$ make run_sim
+$ make run-sim
 ```
 
 Some language limitations are discussed [in the wiki](https://github.com/mpc-sok/frameworks/wiki/CBMC-GC-v2).

--- a/cbmc-gc/README.md
+++ b/cbmc-gc/README.md
@@ -1,12 +1,15 @@
 # CBMC-GC
 
-[CBMC-GC](https://gitlab.com/securityengineering/CBMC-GC-2) is a circuit compiler that produces Boolean circuits from a subset of ANSI-C. It is based on CBMC, a bounded model checker that translates a C program into a boolean constraint; CBMC-GC adapts the output of this tool to produce an optimized circuit. 
-Optimization can be for minimal size or minimal depth circuts (depending on your use case). It supports an arbitrary number of parties.
+[CBMC-GC](https://gitlab.com/securityengineering/CBMC-GC-2) is a circuit compiler that produces Boolean circuits from a subset of ANSI-C. 
+It is based on CBMC, a bounded model checker that translates a C program into a boolean constraint; CBMC-GC adapts the output of this tool to produce an optimized circuit. 
+Optimization can be for minimal size or minimal depth circuts (depending on your use case). 
+It supports an arbitrary number of parties.
 
-CBMC-GC includes a tool for running circuits with [ABY](https://github.com/MPC-SoK/frameworks/tree/master/aby), but we weren't able to use it; the CMBC-GC adapter seems to reference a deprecated ABY API. 
+CBMC-GC includes a tool for running circuits with [ABY](https://github.com/MPC-SoK/frameworks/tree/master/aby), but we weren't able to use it; the CBMC-GC adapter seems to reference a deprecated ABY API. 
 CBMC-GC also includes a tool to output circuits in other formats, but we weren't able to successfully execute any of these (not clear whose fault that is).
 
-CBMC-GC is a circuit compiler produced by Niklas Büscher and others in the [security engineering group at TU Darmstadt](https://forsyte.at/software/cbmc-gc/). This work examines v2.
+CBMC-GC was created by Niklas Büscher and others in the security engineering group at TU Darmstadt. 
+This work examines v2.
 
 Our recommendation: CBMC-GC uses powerful tools to produce optimized circuits, but we were unable to successfully execute any of the circuits it produced.
 
@@ -39,9 +42,8 @@ $ cd ~/CBMC-GC-2/examples/<program>
 $ make
 ```
 
-We have included four example programs: `mult3`, `innerprod`, `xtabs`, and
-`xtabs-hash`. There are also four examples provided by the library that you can
-explore.
+We have included four example programs: `mult3`, `innerprod`, `xtabs`, and `xtabs-hash`. 
+There are also four examples provided by the library that you can explore.
 
 CBMC-GC is purely a circuit compiler: it does not run an MPC computation. In order to test the correctness of a circuit, you can specify a test set and run it _in the clear_. We've provided a tool to generate sample test files for each of our examples.
 ```
@@ -52,8 +54,9 @@ $ make run-sim
 ```
 This runs a _simulation in the clear_. This is not a secure computation.
 
-To run a secure computation, you must use an outside library. CBMC-GC includes
-support to export circuits to ABY, Bristol, Fairplay's SHDL, or the JustGarble format. We have not (yet) explored this functionality.
+To run a secure computation, you must use an outside library. 
+CBMC-GC includes support to export circuits to ABY, Bristol, Fairplay's SHDL, or the JustGarble format. 
+We have not (yet) explored this functionality.
 
 
 ## Modifying Examples
@@ -76,6 +79,4 @@ $ make
 $ make run-sim
 ```
 
-Some language limitations are discussed [in the wiki](https://github.com/mpc-sok/frameworks/wiki/CBMC-GC-v2).
-
-
+Some language limitations are discussed [in the wiki](https://github.com/mpc-sok/frameworks/wiki/CBMC-GC).

--- a/cbmc-gc/README.md
+++ b/cbmc-gc/README.md
@@ -45,7 +45,7 @@ explore.
 
 CBMC-GC is purely a circuit compiler: it does not run an MPC computation. In order to test the correctness of a circuit, you can specify a test set and run it _in the clear_. We've provided a tool to generate sample test files for each of our examples.
 ```
-$ python geninput.py -e <program> -t <# trials>
+$ python3 geninput.py -e <program> -t <# trials>
 $ cd <program>
 $ make run-sim
 ...

--- a/cbmc-gc/install.sh
+++ b/cbmc-gc/install.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 # download source
 git clone https://gitlab.com/securityengineering/CBMC-GC-2.git
@@ -11,5 +12,4 @@ make
 cp bin/cbmc* /usr/bin/
 cp bin/circuit* /usr/bin/
 
-# copy our source
-cp -r ~/source/* examples/
+

--- a/cbmc-gc/install.sh
+++ b/cbmc-gc/install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -ex
+
 # download source
 git clone https://gitlab.com/securityengineering/CBMC-GC-2.git
 cd CBMC-GC-2

--- a/cbmc-gc/runall.sh
+++ b/cbmc-gc/runall.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -ex
+
+examples="mult3 innerprod xtabs" # xtabs-hash takes >1h to compile
+trials=10
+
+cd examples
+
+for ex in $examples; do
+    python geninput.py -e "$ex" -t "$trials"
+    cd "$ex"
+    make
+    make run-sim | grep -q failed && exit 1
+    cd ..
+done
+

--- a/cbmc-gc/runall.sh
+++ b/cbmc-gc/runall.sh
@@ -15,3 +15,4 @@ for ex in $examples; do
     cd ..
 done
 
+echo "Successfully ran all examples"

--- a/cbmc-gc/runall.sh
+++ b/cbmc-gc/runall.sh
@@ -8,7 +8,7 @@ trials=10
 cd examples
 
 for ex in $examples; do
-    python geninput.py -e "$ex" -t "$trials"
+    python3 geninput.py -e "$ex" -t "$trials"
     cd "$ex"
     make
     make run-sim | grep -q failed && exit 1


### PR DESCRIPTION
CBMC-GC is no longer maintained. It cannot be built on Ubuntu 22.04 because its dependency CBMC fails to build.